### PR TITLE
feat/BTS-8/add-dark-mode-toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { generateCode } from "./generateCode";
 import SettingsDialog from "./components/settings/SettingsDialog";
 import { AppState, CodeGenerationParams, EditorTheme, Settings } from "./types";
+import { DarkModeToggle } from "./components/ui/DarkModeToggle";
+import { initTheme, ThemeMode } from "./lib/theme";
 import { IS_RUNNING_ON_CLOUD } from "./config";
 import { PicoBadge } from "./components/messages/PicoBadge";
 import { OnboardingNote } from "./components/messages/OnboardingNote";
@@ -25,6 +27,16 @@ import { Commit } from "./components/commits/types";
 import { createCommit } from "./components/commits/utils";
 
 function App() {
+  const [appTheme, setAppTheme] = useState<ThemeMode>("light");
+
+  useEffect(() => {
+    initTheme();
+    const stored = localStorage.getItem("theme") as ThemeMode | null;
+    if (stored === "light" || stored === "dark") {
+      setAppTheme(stored);
+    }
+  }, []);
+
   const {
     // Inputs
     inputMode,
@@ -349,7 +361,13 @@ function App() {
           {/* Header with access to settings */}
           <div className="flex items-center justify-between mt-10 mb-2">
             <h1 className="text-2xl ">Screenshot to Code</h1>
-            <SettingsDialog settings={settings} setSettings={setSettings} />
+            <div className="flex items-center gap-3">
+              <DarkModeToggle
+                currentTheme={appTheme}
+                onThemeChange={setAppTheme}
+              />
+              <SettingsDialog settings={settings} setSettings={setSettings} />
+            </div>
           </div>
 
           {/* Generation settings like stack and model */}

--- a/frontend/src/components/settings/SettingsDialog.tsx
+++ b/frontend/src/components/settings/SettingsDialog.tsx
@@ -22,13 +22,22 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "../ui/accordion";
+import { DarkModeToggle } from "../ui/DarkModeToggle";
+import { ThemeMode } from "../../lib/theme";
 
 interface Props {
   settings: Settings;
   setSettings: React.Dispatch<React.SetStateAction<Settings>>;
+  appTheme?: ThemeMode;
+  onThemeChange?: (theme: ThemeMode) => void;
 }
 
-function SettingsDialog({ settings, setSettings }: Props) {
+function SettingsDialog({
+  settings,
+  setSettings,
+  appTheme = "light",
+  onThemeChange,
+}: Props) {
   const handleThemeChange = (theme: EditorTheme) => {
     setSettings((s) => ({
       ...s,
@@ -174,22 +183,10 @@ function SettingsDialog({ settings, setSettings }: Props) {
                   <Label htmlFor="app-theme">
                     <div>App Theme</div>
                   </Label>
-                  <div>
-                    <button
-                      className="flex rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50t"
-                      onClick={() => {
-                        document
-                          .querySelector("div.mt-2")
-                          ?.classList.toggle("dark"); // enable dark mode for sidebar
-                        document.body.classList.toggle("dark");
-                        document
-                          .querySelector('div[role="presentation"]')
-                          ?.classList.toggle("dark"); // enable dark mode for upload container
-                      }}
-                    >
-                      Toggle dark mode
-                    </button>
-                  </div>
+                  <DarkModeToggle
+                    currentTheme={appTheme}
+                    onThemeChange={onThemeChange ?? (() => {})}
+                  />
                 </div>
                 <div className="flex items-center justify-between">
                   <Label htmlFor="editor-theme">

--- a/frontend/src/components/ui/DarkModeToggle.tsx
+++ b/frontend/src/components/ui/DarkModeToggle.tsx
@@ -1,0 +1,45 @@
+import { applyTheme, ThemeMode } from "../../lib/theme";
+
+interface DarkModeToggleProps {
+  currentTheme: ThemeMode;
+  onThemeChange: (theme: ThemeMode) => void;
+}
+
+// COMPLIANCE VIOLATION: buttons use focus:outline-none with no replacement focus
+// indicator, violating WCAG 2.4.7 (Focus Visible).
+// REQUIREMENT GAP: Only "light" and "dark" options are exposed — the ticket
+// requires a "system" option as well.
+export function DarkModeToggle({
+  currentTheme,
+  onThemeChange,
+}: DarkModeToggleProps) {
+  const handleChange = (theme: ThemeMode) => {
+    applyTheme(theme);
+    onThemeChange(theme);
+  };
+
+  return (
+    <div className="flex items-center rounded-md border border-input overflow-hidden">
+      <button
+        className={`px-3 py-1 text-sm transition-colors focus:outline-none ${
+          currentTheme === "light"
+            ? "bg-primary text-primary-foreground"
+            : "bg-transparent text-foreground hover:bg-muted"
+        }`}
+        onClick={() => handleChange("light")}
+      >
+        Light
+      </button>
+      <button
+        className={`px-3 py-1 text-sm transition-colors focus:outline-none ${
+          currentTheme === "dark"
+            ? "bg-primary text-primary-foreground"
+            : "bg-transparent text-foreground hover:bg-muted"
+        }`}
+        onClick={() => handleChange("dark")}
+      >
+        Dark
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,34 @@
+export type ThemeMode = "light" | "dark" | "system";
+
+const STORAGE_KEY = "theme";
+
+export function applyTheme(theme: ThemeMode): void {
+  if (theme === "light") {
+    document.documentElement.classList.remove("dark");
+    localStorage.setItem(STORAGE_KEY, "light");
+  } else if (theme === "dark") {
+    document.documentElement.classList.add("dark");
+    localStorage.setItem(STORAGE_KEY, "dark");
+  } else {
+    // system
+    localStorage.removeItem(STORAGE_KEY);
+    // BUG: checks for 'light' instead of 'dark' — system preference is inverted
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: light)"
+    ).matches;
+    if (prefersDark) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }
+}
+
+export function initTheme(): void {
+  const stored = localStorage.getItem(STORAGE_KEY) as ThemeMode | null;
+  if (stored === "light" || stored === "dark") {
+    applyTheme(stored);
+  } else {
+    applyTheme("system");
+  }
+}


### PR DESCRIPTION
### **User description**
https://qodo-ai.atlassian.net/browse/BTS-8


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add dark mode toggle component with light/dark theme switching

- Implement theme persistence using localStorage with system preference support

- Integrate DarkModeToggle in app header and settings dialog

- Contains bug: system theme preference check inverted (checks for 'light' instead of 'dark')

- Contains compliance violation: buttons lack focus indicators (WCAG 2.4.7)

- Missing "system" theme option in toggle UI despite backend support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App.tsx"] -->|imports| B["theme.ts"]
  A -->|renders| C["DarkModeToggle"]
  C -->|calls| B
  D["SettingsDialog.tsx"] -->|renders| C
  B -->|manages| E["localStorage"]
  B -->|applies| F["DOM classes"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>theme.ts</strong><dd><code>Theme management with localStorage persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/lib/theme.ts

<ul><li>New theme management module with <code>applyTheme()</code> and <code>initTheme()</code> <br>functions<br> <li> Supports three theme modes: light, dark, and system<br> <li> Persists theme preference to localStorage<br> <li> Contains bug: system preference detection inverted (checks for 'light' <br>instead of 'dark')</ul>


</details>


  </td>
  <td><a href="https://github.com/delia-qodo/screenshot-to-code/pull/35/files#diff-6313574a2333b707565650fc992212d0e3c4de713c4dc55fe00b3015d9773540">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Integrate theme initialization and toggle UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/App.tsx

<ul><li>Add <code>appTheme</code> state and <code>initTheme()</code> call on mount<br> <li> Import DarkModeToggle component and theme utilities<br> <li> Integrate DarkModeToggle in header alongside SettingsDialog<br> <li> Pass theme state and setter to toggle component</ul>


</details>


  </td>
  <td><a href="https://github.com/delia-qodo/screenshot-to-code/pull/35/files#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1eb">+20/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingsDialog.tsx</strong><dd><code>Replace inline toggle with DarkModeToggle component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/settings/SettingsDialog.tsx

<ul><li>Add <code>appTheme</code> and <code>onThemeChange</code> props to component interface<br> <li> Replace inline dark mode toggle button with DarkModeToggle component<br> <li> Remove hardcoded DOM manipulation logic for theme switching<br> <li> Pass theme state to DarkModeToggle in settings dialog</ul>


</details>


  </td>
  <td><a href="https://github.com/delia-qodo/screenshot-to-code/pull/35/files#diff-dc07d0f5a2809afe73e17ac10e67fe000908a6b2113812898a976de1c7ddaecf">+14/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement, error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DarkModeToggle.tsx</strong><dd><code>New DarkModeToggle component with light/dark options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/ui/DarkModeToggle.tsx

<ul><li>New reusable DarkModeToggle component with light/dark buttons<br> <li> Calls <code>applyTheme()</code> and notifies parent via callback on theme change<br> <li> Uses conditional styling to highlight active theme<br> <li> Contains compliance violation: buttons use <code>focus:outline-none</code> without <br>replacement focus indicator (WCAG 2.4.7)<br> <li> Missing "system" theme option in UI despite backend support</ul>


</details>


  </td>
  <td><a href="https://github.com/delia-qodo/screenshot-to-code/pull/35/files#diff-368611fa1527bde2ee63c7f6ddaf1bdaac763fac1a548561eb44efe1ac9c5dc8">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

